### PR TITLE
Fix reference to Linkwarden

### DIFF
--- a/guides/overview.md
+++ b/guides/overview.md
@@ -9,7 +9,7 @@ If you don't have Google Drive or don't want to use it, using WebDAV may be an o
 Checkout [this list the Cryptomator Community created](https://community.cryptomator.org/t/webdav-urls-of-common-cloud-storage-services/75) to see if your provider offers WebDAV.
 
 If you want a very easy solution, you can sync your bookmarks via Linkwarden. Linkwarden is an Open Source web app that manages your bookmarks. You can host it yourself on your own server, but
-you can also simply signup on their hosted solution at [linkwarden.app](https://linkwarden.app). You can then also access and manage your bookmarks on the go, say from an internet café in Malawi, by simply logging into your Nextcloud with any web browser.
+you can also simply signup on their hosted solution at [linkwarden.app](https://linkwarden.app). You can then also access and manage your bookmarks on the go, say from an internet café in Malawi, by simply logging into Linkwarden with any web browser.
 
 Similar to Linkwarden, but perhaps a bit more involved is syncing via Nextcloud Bookmarks. Nextcloud is an open source cloud collaboration tool that you can self-host or rent as a service.
 Nextcloud offers a multitude of apps to collaborate and share work over, chief amongst them, the Bookmarks app. If you have a Nextcloud installation available,


### PR DESCRIPTION
The sentence was copied verbatim from the prior version, talking about Nextcloud.