### PR TITLE
Git 401 HTTP Error Documentation Changes

### DIFF
--- a/guides/sync-git.md
+++ b/guides/sync-git.md
@@ -2,7 +2,7 @@
 2. Select Git over HTTP as your sync method
 3. The following screens show the profile settings.
 4. First you will need to enter your Git repository URL and a branch to sync to. Make sure to use the HTTPS URL instead of the SSH URL if you have the choice. Also, make sure that the branch already exists and there are no branch rules that prevent direct commits to the branch.
-5. Then enter your username and password for your Git hosting provider. Note, that if you have 2-factor authentication enabled for your account, you will need to use some sort of device token here instead of your actual password.  
+5. Then enter your username and password for your Git hosting provider. Note that is recommended that you use a device token with read/write access to Content here instead of your actual password and may be a requirement, particularly if you have 2-factor authentication enabled for your account.
 6. You can then enter a path and filename for the bookmarks file inside your Git repository. The easiest is to just store it in the root.
 7. Finally, you can choose which bookmarks folder to sync to that file. By default floccus will create a new folder for you, to avoid syncing something that you don’t want synced. However, with a click on the folder icon you can select any other folder in your bookmarks. It is not advised anymore to select the topmost folder, because the built-in bookmarks folders are named differently depending on browser vendor and language, and the original attempt to bridge this gap is no longer possible.
 8. Make sure to disable your native browser bookmark sync service, because it is likely incompatible with floccus

--- a/pages/faq.vue
+++ b/pages/faq.vue
@@ -153,7 +153,11 @@ After two hours of trying floccus should override the lock and finally start syn
           answer: `This error can happen with older versions of Linkwarden. An update to the latest version should fix this. If it doesn't, please file an issue on the floccus github repository.`,
         },
         {
-          question: "I'm seeing 'E034: Remote bookmarks file is unreadable.' errors . What can I do?",
+          question: "I am receiving a 401 HTTP error when trying to set up Floccus with Git.  What can I do?",
+          answer: `Try setting up a device token and using that instead of your personal password. The steps for this can vary depending on the service you are using, but you can find more information here: https://github.com/floccusaddon/floccus/discussions/1655`,
+        },
+        {
+          question: "I'm seeing 'E034: Remote bookmarks file is unreadable.' errors. What can I do?",
           answer: `This error can happen e.g. after you have shutdown your computer while floccus was running. Sometimes that leads to only parts of the bookmarks file getting uploaded, which floccus notices and stops the sync. You can remedy this situation by deleting the file on the server and triggering a sync with floccus, ideally on the device that you last made changes on. Floccus will then re-upload the whole file.`,
         },
         {


### PR DESCRIPTION
Updates the git sync guide and the FAQ to include more information on authenticating with a device token rather than a personal password, since it can be necessary.